### PR TITLE
Update "Internet" option description

### DIFF
--- a/piKiss.sh
+++ b/piKiss.sh
@@ -465,7 +465,7 @@ while true; do
         Info "Info about the Pi or related"
         Multimedia "Help you to install apps like XBMC"
         Configure "Installations are piece of cake now"
-        Internet "All refered to internet"
+        Internet "Tweaks related to internet"
         Server "Use your distro as a server"
         Devs "Help you for making your own apps"
         Others "Scripts with others thematics"


### PR DESCRIPTION
Up to you, but "referred to" might not be the right word to use here. "Related" seems more appropriate IMO. ("[refer to](https://www.merriam-webster.com/dictionary/refer%20to)" implies pointing to, connecting to, or mentioning something (e.g. please refer to Jim for details), whereas "[related to](https://www.merriam-webster.com/dictionary/related)" implies a description of a group of items)