### PR TITLE
Updated emulator options and labels

### DIFF
--- a/piKiss.sh
+++ b/piKiss.sh
@@ -206,7 +206,6 @@ smEmulators() {
             Amiga "Amiga (Amiberry)"
             AMSTRAD_CPC "Amstrad CPC (Caprice32)"
             GBA "Game Boy Advance (mGBA)"
-            Sega "Sega Genesis, Megadrive, Mega CD, 32X (PicoDrive)"
             MAME "Multiple Arcate Machine Emulator (MAME, AdvanceMAME, and/or MAME4ALL-Pi)"
             Mednafen "Portable multi-system emulator (Mednafen)"
             MSDOS "MS-DOS (DOSBox)"
@@ -215,9 +214,10 @@ smEmulators() {
             PSP "PlayStation Portable (PPSSPP)"
             ResidualVM "Cross-platform 3D game interpreter to play LucasArts adventure games and more"
             ScummVM "Emulator for point-and-click adventure games"
+            Sega "Sega Genesis, Megadrive, Mega CD, 32X (PicoDrive)"
             SNES "Super NES (Snes9X 1.60)"
-            ZX_Spectrum "ZX Spectrum (Speccy)"
             Wii_GC "[EXPERIMENTAL] Wii & Gamecube (Dolphin)"
+            ZX_Spectrum "ZX Spectrum (Speccy)"
         )
     fi
 
@@ -229,7 +229,6 @@ smEmulators() {
         Amiga) ./scripts/emus/amiga.sh ;;
         AMSTRAD_CPC) ./scripts/emus/caprice.sh ;;
         GBA) ./scripts/emus/gba.sh ;;
-        Sega) ./scripts/emus/genesis.sh ;;
         MAME) ./scripts/emus/mame4allpi.sh ;;
         Mednafen) ./scripts/emus/mednafen.sh ;;
         MSDOS) ./scripts/emus/rpix86.sh ;;
@@ -238,9 +237,10 @@ smEmulators() {
         PSP) ./scripts/emus/psp.sh ;;
         ResidualVM) ./scripts/emus/residual.sh ;;
         ScummVM) ./scripts/emus/scummvm.sh ;;
+        Sega) ./scripts/emus/genesis.sh ;;
         SNES) ./scripts/emus/pisnes.sh ;;
-        ZX_Spectrum) ./scripts/emus/speccy.sh ;;
         Wii_GC) ./scripts/emus/dolphin.sh ;;
+        ZX_Spectrum) ./scripts/emus/speccy.sh ;;
         esac
     done
 }

--- a/piKiss.sh
+++ b/piKiss.sh
@@ -203,21 +203,21 @@ smEmulators() {
     if [[ ${MODEL} == 'Raspberry Pi' ]]; then
         options=(
             Back "Back to main menu"
-            Amiga "Amiberry is an Amiga emulator"
-            Caprice "Amstrad CPC with Caprice32"
-            Dolphin "Dolphin is a Wii & Gamecube emulator (EXPERIMENTAL)"
-            DOSBox "DOSBox is a MS-DOS emulator"
-            Gba "Gameboy Advance (mgba)"
-            Genesis "Genesis Megadrive Emulator (picodrive)"
+            Amiga "Amiga (Amiberry)"
+            AMSTRAD_CPC "Amstrad CPC (Caprice32)"
+            GBA "Game Boy Advance (mGBA)"
+            Sega "Sega Genesis, Megadrive, Mega CD, 32X (PicoDrive)"
+            MAME "Multiple Arcate Machine Emulator (MAME, AdvanceMAME, and/or MAME4ALL-Pi)"
             Mednafen "Portable multi-system emulator (Mednafen)"
-            Mame "Install MAME, Advance MAME and/or MAME4ALL-PI"
-            MSX "openMSX"
-            Pifba "Emulates old arcade games using CPS1, CPS2,..."
-            PSP "PPSSPP can run your PSP games on your RPi in full HD resolution"
-            ResidualVM "Cross-platform 3D game interpreter to play some games"
-            ScummVM "Allow gamers to play point-and-click adventure games"
-            Snes "SNES Emulator Snes9X 1.60"
-            Speccy "ZX-Spectrum emulator"
+            MSDOS "MS-DOS (DOSBox)"
+            MSX "MSX (openMSX)"
+            PiFBA "Emulates old arcade games using MAME ROMS for CPS1, CPS2, and more"
+            PSP "PlayStation Portable (PPSSPP)"
+            ResidualVM "Cross-platform 3D game interpreter to play LucasArts adventure games and more"
+            ScummVM "Emulator for point-and-click adventure games"
+            SNES "Super NES (Snes9X 1.60)"
+            ZX_Spectrum "ZX Spectrum (Speccy)"
+            Wii_GC "[EXPERIMENTAL] Wii & Gamecube (Dolphin)"
         )
     fi
 
@@ -227,20 +227,20 @@ smEmulators() {
         case $choice in
         Back) break ;;
         Amiga) ./scripts/emus/amiga.sh ;;
-        Caprice) ./scripts/emus/caprice.sh ;;
-        Dolphin) ./scripts/emus/dolphin.sh ;;
-        DOSBox) ./scripts/emus/rpix86.sh ;;
-        Gba) ./scripts/emus/gba.sh ;;
-        Genesis) ./scripts/emus/genesis.sh ;;
+        AMSTRAD_CPC) ./scripts/emus/caprice.sh ;;
+        GBA) ./scripts/emus/gba.sh ;;
+        Sega) ./scripts/emus/genesis.sh ;;
+        MAME) ./scripts/emus/mame4allpi.sh ;;
         Mednafen) ./scripts/emus/mednafen.sh ;;
-        Mame) ./scripts/emus/mame4allpi.sh ;;
+        MSDOS) ./scripts/emus/rpix86.sh ;;
         MSX) ./scripts/emus/msx.sh ;;
+        PiFBA) ./scripts/emus/pifba.sh ;;
         PSP) ./scripts/emus/psp.sh ;;
-        Pifba) ./scripts/emus/pifba.sh ;;
         ResidualVM) ./scripts/emus/residual.sh ;;
         ScummVM) ./scripts/emus/scummvm.sh ;;
-        Snes) ./scripts/emus/pisnes.sh ;;
-        Speccy) ./scripts/emus/speccy.sh ;;
+        SNES) ./scripts/emus/pisnes.sh ;;
+        ZX_Spectrum) ./scripts/emus/speccy.sh ;;
+        Wii_GC) ./scripts/emus/dolphin.sh ;;
         esac
     done
 }

--- a/piKiss.sh
+++ b/piKiss.sh
@@ -213,7 +213,7 @@ smEmulators() {
             PiFBA "Emulates old arcade games using MAME ROMS for CPS1, CPS2, and more"
             PSP "PlayStation Portable (PPSSPP)"
             ResidualVM "Cross-platform 3D game interpreter to play LucasArts adventure games and more"
-            ScummVM "Emulator for point-and-click adventure games"
+            ScummVM "Emulator for SCUMM-based point-and-click adventure games"
             Sega "Sega Genesis, Megadrive, Mega CD, 32X (PicoDrive)"
             SNES "Super NES (Snes9X 1.60)"
             Wii_GC "[EXPERIMENTAL] Wii & Gamecube (Dolphin)"

--- a/piKiss.sh
+++ b/piKiss.sh
@@ -204,7 +204,7 @@ smEmulators() {
         options=(
             Back "Back to main menu"
             Amiga "Amiga (Amiberry)"
-            AMSTRAD_CPC "Amstrad CPC (Caprice32)"
+            Amstrad_CPC "Amstrad CPC (Caprice32)"
             GBA "Game Boy Advance (mGBA)"
             MAME "Multiple Arcate Machine Emulator (MAME, AdvanceMAME, and/or MAME4ALL-Pi)"
             Mednafen "Portable multi-system emulator (Mednafen)"
@@ -227,7 +227,7 @@ smEmulators() {
         case $choice in
         Back) break ;;
         Amiga) ./scripts/emus/amiga.sh ;;
-        AMSTRAD_CPC) ./scripts/emus/caprice.sh ;;
+        Amstrad_CPC) ./scripts/emus/caprice.sh ;;
         GBA) ./scripts/emus/gba.sh ;;
         MAME) ./scripts/emus/mame4allpi.sh ;;
         Mednafen) ./scripts/emus/mednafen.sh ;;


### PR DESCRIPTION
Cleaned up the emulator options a bit:

### Changelog
- `Amiga`
  - updated description to follow the `<long-system-name> (<emulator>)` pattern
- `Caprice`
  - renamed to `Amstrad_CPC` to follow the `<short-system-name>` pattern
  - updated description to follow the `<long-system-name> (<emulator>)` pattern
- `Dolphin`
  - renamed to `Wii_GC` to follow the `<short-system-name>` pattern
  - moved "EXPERIMENTAL` to the front of the description (hopefully this will make it more clear to new users)
  - updated description to follow the `<long-system-name> (<emulator>)` pattern
- `DOSBox`
  - renamed to `MSDOS` to follow the system-name label pattern
  - updated description to follow the `<long-system-name> (<emulator>)` pattern
- `Gba`
  - renamed to `GBA` to match official style
  - renamed `Gameboy Advance` to `Game Boy Advance` to match the official style
  - renamed `mgba` to `mGBA` to match the official style 
- `Genesis`
  - renamed to `Sega` (it emulates more than just the Genesis!)
  - added missing systems to description
  - renamed `picodrive` to `PicoDrive` to match the official style
- `Mame`
  - fixed style on label to match the official style
  - updated description to follow the `<long-system-name> (<emulator>)` pattern
  - renamed the `MAME3ALL-PI` to `MAME3ALL-Pi` to match the official style
- `MSX`
  - updated description to follow the `<long-system-name> (<emulator>)` pattern
- `Pifba`
  - renamed to `PiFBA` to match the official style
- `PSP`
  - updated description to follow the `<long-system-name> (<emulator>)` pattern
- `ResidualVM`
  - updated description to describe the intention of the emulator (replaced "some games" with "LucasArts adventure games and more")
- `ScummVM`
  - added emulated system (SCUMM) to description
- `Snes`
  - renamed to SNES to match official style
  - updated description to follow the `<long-system-name> (<emulator>)` pattern
- `Speccy`
  - renamed to `Speccy` to follow the `<short-system-name>` pattern
  - updated description to follow the `<long-system-name> (<emulator>)` pattern
- alphabetized emulator options