### PR TITLE
change the gl4es compile target if mesa is present

### DIFF
--- a/scripts/others/gl4es.sh
+++ b/scripts/others/gl4es.sh
@@ -28,7 +28,11 @@ compile() {
         rm -r build
     fi
     mkdir build && cd "$_" || exit 1
-    cmake .. -DBCMHOST=1 -DCMAKE_BUILD_TYPE=RELEASE
+    if [ "$(dpkg -l | awk '/mesa0/ {print }'|wc -l)" -ge 1 ]; then
+        cmake .. -DBCMHOST=1 -DCMAKE_BUILD_TYPE=RELEASE
+    else
+        cmake .. -DODROID=1 -DCMAKE_BUILD_TYPE=RELEASE
+    fi
     make_with_all_cores
     echo -e "\nDone!. You can found the library at $COMPILE_PATH/lib"
     exit_message


### PR DESCRIPTION
piKiss uses the compilation profile for old legacy drivers (for non-mesa)
`cmake .. -DBCMHOST=1 -DCMAKE_BUILD_TYPE=RELEASE` 

The compilation guide from gl4es says to use the Odroid profile (for mesa)
`cmake .. -DODROID=1 -DCMAKE_BUILD_TYPE=RELEASE`

https://github.com/ptitSeb/gl4es/blob/master/COMPILE.md#raspberry-pi

this made the library unusable for me:

```
LD_LIBRARY_PATH="/home/pi/sc/gl4es/lib/" glxgears 

LIBGL: Initialising gl4es
LIBGL: v1.1.5 built on Feb  9 2021 17:39:45
LIBGL: Using GLES 2.0 backend
LIBGL: loaded: libbcm_host.so
LIBGL: loaded: libvcos.so
LIBGL: loaded: libbrcmGLESv2.so
LIBGL: loaded: libbrcmEGL.so
LIBGL: Using GLES 2.0 backend
* failed to add service - already in use?
```