### PR TITLE
Fixing missing installation code

### DIFF
--- a/scripts/emus/retroarch.sh
+++ b/scripts/emus/retroarch.sh
@@ -134,6 +134,7 @@ install_assets() {
 
 install() {
     local BINARY_URL_INSTALL=$BINARY_URL
+    CODENAME=$(get_codename)
 
     echo -e "Installing package and dependencies..."
 


### PR DESCRIPTION
My script did not determine that I had Debian Buster. And the same piece of code was in the DuckStation script.