### PR TITLE
Build fixes and improvements for Vulkan leasing and OpenGL interop.

### DIFF
--- a/scripts/config/vulkan.sh
+++ b/scripts/config/vulkan.sh
@@ -105,7 +105,7 @@ compile() {
         EXTRA_PARAM="-mcpu=cortex-a72 -mfpu=neon-fp-armv8"
     fi
 
-    meson --prefix /usr -Dgles1=disabled -Dgles2=enabled -Dplatforms=x11 -Dvulkan-drivers=broadcom -Ddri-drivers= -Dgallium-drivers=v3d,kmsro,vc4,virgl -Dbuildtype=release -Dc_args="$EXTRA_PARAM" -Dcpp_args="$EXTRA_PARAM" build
+    meson --prefix /usr -Dgles1=disabled -Dgles2=enabled -Dplatforms=x11 -Dvulkan-drivers=broadcom -Dgallium-drivers=v3d,kmsro,vc4,virgl -Dbuildtype=release -Dc_args="$EXTRA_PARAM" -Dcpp_args="$EXTRA_PARAM" build
     echo -e "\nCompiling... \n"
     time ninja -C build -j"$(nproc)"
     install

--- a/scripts/config/vulkan.sh
+++ b/scripts/config/vulkan.sh
@@ -105,7 +105,7 @@ compile() {
         EXTRA_PARAM="-mcpu=cortex-a72 -mfpu=neon-fp-armv8"
     fi
 
-    meson --prefix /usr -Dgles1=disabled -Dgles2=enabled -Dplatforms=x11 -Dvulkan-drivers=broadcom -Dgallium-drivers=v3d,kmsro,vc4,virgl -Dbuildtype=release -Dc_args="$EXTRA_PARAM" -Dcpp_args="$EXTRA_PARAM" build
+    meson --prefix /usr -Dgles1=disabled -Dgles2=enabled -Dplatforms=x11 -Dxlib-lease=auto -Dvulkan-drivers=broadcom -Dgallium-drivers=v3d,kmsro,vc4,virgl -Dbuildtype=release -Dc_args="$EXTRA_PARAM" -Dcpp_args="$EXTRA_PARAM" build
     echo -e "\nCompiling... \n"
     time ninja -C build -j"$(nproc)"
     install

--- a/scripts/config/vulkan.sh
+++ b/scripts/config/vulkan.sh
@@ -105,7 +105,7 @@ compile() {
         EXTRA_PARAM="-mcpu=cortex-a72 -mfpu=neon-fp-armv8"
     fi
 
-    meson --prefix /usr -Dgles1=disabled -Dgles2=enabled -Dplatforms=x11 -Dxlib-lease=auto -Dvulkan-drivers=broadcom -Dgallium-drivers=v3d,kmsro,vc4,virgl -Dbuildtype=release -Dc_args="$EXTRA_PARAM" -Dcpp_args="$EXTRA_PARAM" build
+    meson --prefix /usr -Dgles1=disabled -Dgles2=enabled -Dplatforms=x11 -Dxlib-lease=auto -Dvulkan-drivers=broadcom -Dgallium-drivers=v3d,kmsro,vc4,virgl,zink -Dbuildtype=release -Dc_args="$EXTRA_PARAM" -Dcpp_args="$EXTRA_PARAM" build
     echo -e "\nCompiling... \n"
     time ninja -C build -j"$(nproc)"
     install


### PR DESCRIPTION
Hi, great project of yours, tried it recently and it makes installing Vulkan drivers from Mesa upstream
really easy! I say that as a Mesa developer myself, who likes the convenience you bring to the RPi
with this!

Here are some improvements I needed to make:

- A build fix against current Mesa main / upcoming Mesa 23.1.
- The ability to take over video outputs from the X-Server for Vulkan direct display mode for high performance, which will become available in Mesa main / upcoming Mesa 23.1.
- The ability to use zink for OpenGL+Vulkan interop to allow applications to work which need both OpenGL and Vulkan rendering, like my own application Psychtoolbox (available in RPi OS as octave-psychtoolbox-3 package).

Have a nice day and thanks for your work!