### PR TITLE
install: exit with error code 1 on failure

### DIFF
--- a/res/install.sh
+++ b/res/install.sh
@@ -41,7 +41,7 @@ install() {
 
     if [[ -z $IS_RASPBERRYPI ]]; then
         echo "Sorry. PiKISS is only available for Raspberry Pi boards."
-        exit
+        exit 1
     fi
 
     echo -e "\nPiKISS\n======\n\nInstalling at ${INSTALL_DIR}/piKiss. Please wait...\n"


### PR DESCRIPTION
## 📑 Description
exit with error code when not a raspberry pi so that scripts that execute this can tell that it exited with an error