### PR TITLE
remove unsafe vulkan installation

### DIFF
--- a/piKiss.sh
+++ b/piKiss.sh
@@ -334,7 +334,7 @@ smConfigure() {
 
     options=(
         Back "Back to main menu"
-        Vulkan "Compile/update Vulkan Mesa driver"
+        Vulkan "Install Vulkan Mesa driver"
         SSIDCfg "Configure SSID (WPA/WPA2 with PSK)"
         Joypad "Configure WII, XBox360 controller"
         Backup "Simple backup dir to run daily"

--- a/scripts/config/vulkan.sh
+++ b/scripts/config/vulkan.sh
@@ -14,57 +14,6 @@
 clear
 check_board || { echo "Missing file helper.sh. I've tried to download it for you. Try to run the script again." && exit 1; }
 
-readonly INSTALL_DIR="$HOME/mesa_vulkan"
-readonly SOURCE_CODE_URL="https://gitlab.freedesktop.org/mesa/mesa.git"
-readonly LIB_DRM_VERSION="2.4.120" # Get the latest version at https://dri.freedesktop.org/libdrm/?C=M;O=D
-readonly VULKAN_INSTALL_SCRIPT_URL="https://gist.githubusercontent.com/jmcerrejon/a08eca2bba3e5e23bda2b3f7d7506ab0/raw/11aad2190e1244821571788c4b143c6970f476e0/reinstall-vulkan-driver.sh"
-PI_VERSION_NUMBER=$(get_pi_version_number)
-BRANCH_VERSION="mesa-24.0.0"
-INPUT=/tmp/vulkan.$$
-
-install() {
-    echo -e "\nInstalling...\n"
-    cd "$INSTALL_DIR" || exit
-    sudo ninja -C build install > /dev/null 2>&1
-    echo
-    add_reinstall_service
-    echo
-    glxinfo -B
-    echo "Done."
-    exit_message
-}
-
-install_full_deps() {
-    echo -e "\nInstalling deps...\n"
-    sudo apt-get install -y libxcb-randr0-dev libxrandr-dev \
-        libxcb-xinerama0-dev libxinerama-dev libxcursor-dev \
-        libxcb-cursor-dev libxkbcommon-dev xutils-dev \
-        xutils-dev libpthread-stubs0-dev libpciaccess-dev \
-        libffi-dev x11proto-xext-dev libxcb1-dev libxcb-*dev \
-        bison flex libssl-dev libgnutls28-dev x11proto-dri2-dev \
-        libx11-dev libxcb-glx0-dev \
-        libx11-xcb-dev libxext-dev libxdamage-dev libxfixes-dev \
-        libva-dev x11proto-randr-dev x11proto-present-dev \
-        libelf-dev git build-essential mesa-utils \
-        libvulkan-dev ninja-build libvulkan1 python3-mako \
-        libdrm-dev libxshmfence-dev libxxf86vm-dev libwayland-dev \
-        python3-mako wayland-protocols libwayland-egl-backend-dev \
-        cmake libassimp-dev python3-pip
-    # x11proto-dri3-dev missing on Debian Bullseye
-    if is_userspace_64_bits; then
-        sudo apt install -y libclc-16-dev
-    else
-        sudo apt install -y libclc-dev
-    fi
-    install_meson
-}
-
-clone_repo() {
-    echo -e "\nCloning mesa repo...\n"
-    cd || exit
-    git clone -b "$BRANCH_VERSION" "$SOURCE_CODE_URL" "$INSTALL_DIR" && cd "$_" || exit
-}
-
 install_vulkan_from_official_repository() {
     local CODENAME
     CODENAME=$(get_codename)
@@ -82,99 +31,17 @@ install_vulkan_from_official_repository() {
     exit_message
 }
 
-compile_and_install_libdrm() {
-    local LIBDRM_URL
-    local SOURCE_CODE_PATH
-    FILE_NAME="libdrm-$LIB_DRM_VERSION"
-    LIBDRM_URL="https://dri.freedesktop.org/libdrm/$FILE_NAME.tar.xz"
-    SOURCE_CODE_PATH="$HOME/sc"
-
-    echo -e "\nCompiling libdrm...\n"
-    download_and_extract "$LIBDRM_URL" "$SOURCE_CODE_PATH"
-    cd "$FILE_NAME" || exit
-    [[ ! -d build ]] && mkdir build
-    cd build || exit
-    meson setup --wipe -Dudev=true -Dvc4=auto -Dintel=disabled -Dvmwgfx=disabled -Dradeon=disabled -Damdgpu=disabled -Dnouveau=disabled -Dfreedreno=disabled -Dinstall-test-programs=true ..
-    time ninja -C . -j"$(nproc)"
-    sudo ninja install
-    echo "Compiled & installed onto your system. Move on..."
-}
-
-compile() {
-    local EXTRA_PARAM
-    EXTRA_PARAM="-mcpu=cortex-a72 -mfpu=neon-fp-armv8"
-
-    [[ -d $INSTALL_DIR ]] && rm -rf "$INSTALL_DIR"
-    install_full_deps
-    compile_and_install_libdrm
-    clone_repo
-
-    [[ -d "$INSTALL_DIR"/build ]] && rm -rf "$INSTALL_DIR"/build
-
-    if is_userspace_64_bits; then
-        EXTRA_PARAM="-mcpu=cortex-a72"
-    fi
-
-    meson setup --prefix /usr -Dgles1=disabled -Dgles2=enabled -Dplatforms=x11 -Dxlib-lease=auto -Dvulkan-drivers=broadcom -Dgallium-drivers=v3d,kmsro,vc4,virgl,zink -Dbuildtype=release -Dc_args="$EXTRA_PARAM" -Dcpp_args="$EXTRA_PARAM" build
-    echo -e "\nCompiling... \n"
-    time ninja -C build -j"$(nproc)"
-    install
-}
-
-function add_reinstall_service() {
-    local SCRIPT_PATH="$INSTALL_DIR/reinstall-vulkan-driver.sh"
-    local REINSTALL_VULKAN_DRIVER_HOOK="/etc/apt/apt.conf.d/99reinstall-vulkan-driver-hook"
-
-    echo -e "\nAdding service to re-install Vulkan driver on each apt upgrade/update..."
-    download_file "$VULKAN_INSTALL_SCRIPT_URL" "$INSTALL_DIR"
-    if [[ ! -f $SCRIPT_PATH ]]; then
-        echo "Error: Can't download the script to reinstall the Vulkan driver. Skippping process."
-        return 1
-    fi
-
-    chmod +x "$SCRIPT_PATH"
-    echo "DPkg::Post-Invoke {'if [ -x ${SCRIPT_PATH} ]; then ${SCRIPT_PATH}; fi';};" | sudo tee "$REINSTALL_VULKAN_DRIVER_HOOK" >/dev/null
-}
-
-menu_choose_branch() {
-    while true; do
-        dialog --clear \
-            --title "[ Vulkan Branch ]" \
-            --menu "Select from the list:" 11 100 3 \
-            repo "(Recommended) Not latest but stable from official repository." \
-            stable "(Safe) Latest stable branch working ${BRANCH_VERSION}." \
-            main "(Latest) NOT stable at all. Install at your own risk." \
-            Exit "Exit" 2>"${INPUT}"
-
-        menuitem=$(<"${INPUT}")
-
-        case $menuitem in
-        repo) install_vulkan_from_official_repository ;;
-        stable) compile ;;
-        main) BRANCH_VERSION="main" && compile ;;
-        Exit) exit ;;
-        esac
-    done
-}
-
 install_script_message
 echo "
 Vulkan Mesa Drivers
 ===================
 
-WARNING! Issue reported: If you can't see the desktop after apt upgrade/update, you have to reinstall the driver again, so: cd $HOME/mesa_vulkan/build && sudo ninja install.
-THIS script installs for you a service to re-install the driver on each apt upgrade/update as a temporal solution.
-
-· Support 32/64 bits.
-· This process can't be undone.
-· Make sure you backup your data.
-· This script installs/compiles libdrm & Vulkan Mesa Driver on your OS.
-· Estimated compilation time on Raspberry Pi 4 ~19 min & Pi 5 ~7 min over USB/SSD drive (Not overclocked).
+Installs vulkan drivers from official apt repositories.
 "
 read -p "Continue? (Y/n) " response
 if [[ $response =~ [Nn] ]]; then
     exit_message
 fi
 upgrade_dist
-menu_choose_branch
+install_vulkan_from_official_repository
 exit_message


### PR DESCRIPTION
closes https://github.com/jmcerrejon/PiKISS/issues/210
closes https://github.com/jmcerrejon/PiKISS/issues/209

## 📑 Description
Removes unsafe vulkan installation that overwrites system packages and breaks users installs.

## ℹ Additional Information
If the developer wishes to re-add these in a safe manner here is what needs to be done:

1. install to a path not managed by the package manager (eg: `/usr/local`). All files can be installed there and are preferred over the main location (eg: `/usr/local/bin` `/usr/local/share` `/usr/local/vulkan/`, etc). Refer to the loader documentation for further explanation https://vulkan.lunarg.com/doc/view/1.3.275.0/linux/loader_and_layer_interface.html
2. Remove all online components and apt hook (with 1., they are not needed). They are dangerous (prone to fail) and are broken by design (only work if the system is online and the current user running apt/dpkg has the required directory in their $HOME directory, multi-user systems are thus broken)

The developer should add their own cleanup script to fix broken user installs caused by their previous script mistakes. The developer should send a notification to all users (via whatever method available to them) for the affected users. These are not covered in the context of this PR.